### PR TITLE
feat: permit more tags in player messages

### DIFF
--- a/src/main/java/de/ayont/lpc/chat/PlayerMessages.java
+++ b/src/main/java/de/ayont/lpc/chat/PlayerMessages.java
@@ -22,19 +22,24 @@ public final class PlayerMessages {
      * Creates a MiniMessage instance that only understands cosmetic tags: colors, decorations,
      * gradients, rainbow and reset. Everything else is treated as literal text.
      *
-     * @param allowGradients whether {@code <gradient>} and {@code <rainbow>} are permitted
+     * @param allowGradients whether {@code <gradient>}, {@code <transition>}, {@code <rainbow>},
+     *        and {@code <pride>} are permitted
      * @return a restricted MiniMessage instance suitable for player-supplied input
      */
     public static MiniMessage colorParser(boolean allowGradients) {
         TagResolver resolver = allowGradients
                 ? TagResolver.resolver(
                         StandardTags.color(),
+                        StandardTags.shadowColor(),
                         StandardTags.decorations(),
                         StandardTags.gradient(),
+                        StandardTags.transition(),
                         StandardTags.rainbow(),
+                        StandardTags.pride(),
                         StandardTags.reset())
                 : TagResolver.resolver(
                         StandardTags.color(),
+                        StandardTags.shadowColor(),
                         StandardTags.decorations(),
                         StandardTags.reset());
         return MiniMessage.builder().tags(resolver).build();


### PR DESCRIPTION
There are some tags which are safe to allow players to use, but that aren't allowed in the current version of the plugin. This PR adds support for the following tags

- `<shadow>` which changes the color of the drop shadow of text
- `<transition>` which can set the color of a message to any point on a gradient
  - There isn't a ton of use for this in chat, but it should be safe, so I figured why not
- `<pride>` for pre-made pride-flavored gradients