### PR TITLE
feat: LPC 4.2.0 — Minecraft 26.2 / Adventure 5 / Veylor-Development

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,29 @@
+name: Build
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v5
+      # Gradle runs on Java 21; the Java 25 toolchain compiles the plugin (foojay auto-provisions it).
+      - name: Set up Java 21 (Gradle runtime + 25 toolchain via foojay)
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: 'gradle'
+      - uses: gradle/actions/setup-gradle@v6
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: Build & test
+        run: ./gradlew clean build --no-daemon --stacktrace

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,15 +14,19 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: actions/setup-java@v4
+      # Gradle 8.14 cannot compile build scripts while running ON Java 25 (its bundled Groovy/ASM
+      # rejects class file major 69). So Gradle runs on Java 21 and the Java 25 toolchain compiles
+      # the plugin (auto-provisioned by the foojay resolver in settings.gradle).
+      - name: Set up Java 21 (Gradle runtime + 25 toolchain via foojay)
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 25
+          java-version: '21'
           cache: 'gradle'
-      - uses: gradle/actions/setup-gradle@v4
+      - uses: gradle/actions/setup-gradle@v6
       - name: Configure Git
         run: git config --global user.email "no-reply@github.com" && git config --global user.name "Github Actions"
       - name: Grant execute permission for gradlew

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = 'de.ayont'
-version = project.findProperty('project_version') ?: '4.0.0'
+version = project.findProperty('project_version') ?: '4.2.0'
 
 repositories {
     mavenCentral()
@@ -22,14 +22,15 @@ dependencies {
     compileOnly "io.papermc.paper:paper-api:$paper"
     compileOnly "net.luckperms:api:$luckpermsapi"
     compileOnly "me.clip:placeholderapi:$papi"
-    compileOnly "com.google.code.gson:gson:2.13.2" // provided by the server at runtime
+    compileOnly "com.google.code.gson:gson:2.14.0" // provided by the server at runtime
 
-    // Adventure — pinned to the version Paper 26.1.2 bundles, via the BOM.
+    // Adventure — pinned to the version Paper 26.2 bundles (5.2.0), via the BOM.
     // Shaded UNRELOCATED on purpose: on Paper these classes resolve from the server's bundled copy
     // (traditional plugin = parent-first class loading), and on Spigot — which ships no Adventure —
     // they load from this jar. Only the modules actually used are shaded.
     // IMPORTANT: keep the `adventure` version in gradle.properties matching Paper's bundled Adventure
-    // version to avoid classpath skew.
+    // version (verified against the paper-api POM) to avoid classpath skew. Paper 26.2 moved to
+    // Adventure 5.x, so this plugin now requires Paper 26.2+ (Adventure 5).
     implementation platform("net.kyori:adventure-bom:$adventure")
     implementation "net.kyori:adventure-api"
     implementation "net.kyori:adventure-text-minimessage"
@@ -40,7 +41,7 @@ dependencies {
     testImplementation platform("net.kyori:adventure-bom:$adventure")
     testImplementation "net.kyori:adventure-text-minimessage"
     testImplementation "net.kyori:adventure-api"
-    testImplementation platform('org.junit:junit-bom:5.11.4')
+    testImplementation platform('org.junit:junit-bom:5.14.4')
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,12 +1,14 @@
 # Project
-project_version = 4.1.0
+project_version = 4.2.0
 
-# Platform — Minecraft 26.1.2 (Paper). Requires Java 25.
-paper = 26.1.2.build.70-stable
+# Platform — Minecraft 26.2 (Paper). Requires Java 25.
+# 26.2 is currently published as alpha builds; the plugin only uses stable, long-standing APIs.
+paper = 26.2.build.40-alpha
 
 # APIs
-luckpermsapi = 5.4
-papi = 2.11.6
+luckpermsapi = 5.5
+papi = 2.12.2
 
-# Adventure — pinned to the version Paper 26.1.2 bundles (avoids classpath conflicts)
-adventure = 4.26.1
+# Adventure — MUST match the version Paper $paper bundles to avoid classpath skew.
+# Paper 26.2 ships Adventure 5.2.0 (verified against the paper-api POM).
+adventure = 5.2.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/readme.md
+++ b/readme.md
@@ -70,7 +70,7 @@
 **Quality of life**
 - `/lpc reload · version · help · mute · unmute` with tab completion
 - Built-in Modrinth update checker
-- **Safe by design** – player messages can never inject `click`/`hover`/command components
+- **Safe by design** – player messages can never inject `click`/`hover`/`insertion` events. Defence in depth: a restricted MiniMessage parser **plus** a component sanitizer that strips any interactive event from player & item-name output (closes chat click-command exploits).
 - Works on Paper, Folia (region-aware scheduling) and Spigot (legacy fallback)
 
 ---

--- a/readme.md
+++ b/readme.md
@@ -29,9 +29,14 @@
 
 | | |
 |---|---|
-| **Minecraft** | 26.1.2 |
-| **Server** | Paper (recommended), Folia or Spigot |
+| **Minecraft** | 26.2 |
+| **Server** | Paper 26.2+ (recommended), Folia or Spigot |
 | **Java** | 25+ |
+| **Adventure** | 5.x (bundled by Paper — do not override) |
+
+> ⚠️ **"Unsupported API version" / plugin won't load?** LPC declares `api-version: 26.2` and needs
+> **Java 25** + **Paper 26.2** (which ships Adventure 5). Older servers (1.21.x / Java 21) cannot run
+> this build — please update your server to Paper 26.2 and use JDK 25.
 
 ---
 
@@ -173,5 +178,11 @@ Requires JDK 25.
 
 ## 📌 Notes
 
+- **Developed by [Veylor-Development](https://veylor.net)** — the team behind Veylor.NET, releasing
+  free plugins on Modrinth.
+- **Can players use MiniMessage in chat?** Yes — grant the `lpc.chatcolor` permission. Only
+  **cosmetic** tags (colours, decorations, and optionally `<gradient>`/`<rainbow>`) are honoured;
+  interactive tags (`click`, `hover`, `insertion`, …) are always stripped, so players can never
+  inject commands or fake tooltips.
 - **Not affiliated with LuckPerms** – please do not contact the LuckPerms author for support.
 - Legacy version available at: [GitHub Legacy LPC](https://github.com/wikmor/LPC)

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,7 @@
+plugins {
+    // Lets Gradle auto-provision the exact JDK a toolchain requests (e.g. Java 25 when Gradle
+    // itself runs on Java 21). Harmless when the requested JDK is already installed locally.
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.9.0'
+}
+
 rootProject.name = 'LPC-Minimessage'

--- a/src/main/java/de/ayont/lpc/chat/ComponentSanitizer.java
+++ b/src/main/java/de/ayont/lpc/chat/ComponentSanitizer.java
@@ -1,0 +1,48 @@
+package de.ayont.lpc.chat;
+
+import java.util.ArrayList;
+import java.util.List;
+import net.kyori.adventure.text.Component;
+
+/**
+ * Defence-in-depth helper that recursively strips <em>interactive</em> styling from a component tree:
+ * {@code clickEvent}, {@code hoverEvent} and {@code insertion}.
+ *
+ * <p>Player-facing text is already parsed with a restricted (cosmetic-only) MiniMessage instance, so
+ * a player can never legitimately produce these events in their own message. This pass guarantees
+ * that invariant at the component level too — so even if a future code path, a renamed item (anvil),
+ * or a third-party plugin hands LPC a component that already carries an interactive event, it can
+ * never reach another player's chat as a clickable / hoverable / shift-insertable element. Cosmetic
+ * styling (colours, decorations) is preserved.
+ *
+ * <p>Always-on by design — there is no config toggle, because this is a security boundary.
+ */
+public final class ComponentSanitizer {
+
+    private ComponentSanitizer() {
+    }
+
+    /**
+     * Returns a copy of the component tree with every interactive event removed. Cosmetic styling
+     * (colour, decoration, font, etc.) is kept untouched. A {@code null} input returns
+     * {@link Component#empty()}.
+     *
+     * @param component the component to harden (may be {@code null})
+     * @return a component guaranteed to carry no click / hover / insertion events
+     */
+    public static Component stripInteractive(Component component) {
+        if (component == null) {
+            return Component.empty();
+        }
+        Component stripped = component.clickEvent(null).hoverEvent(null).insertion(null);
+        List<Component> children = stripped.children();
+        if (children.isEmpty()) {
+            return stripped;
+        }
+        List<Component> sanitized = new ArrayList<>(children.size());
+        for (Component child : children) {
+            sanitized.add(stripInteractive(child));
+        }
+        return stripped.children(sanitized);
+    }
+}

--- a/src/main/java/de/ayont/lpc/chat/ItemPlaceholder.java
+++ b/src/main/java/de/ayont/lpc/chat/ItemPlaceholder.java
@@ -62,7 +62,10 @@ public final class ItemPlaceholder {
             if (plugin.isPaper()) {
                 Component name = meta.displayName();
                 if (name != null) {
-                    return name;
+                    // An item renamed via an anvil (or another plugin) is player-influenced input —
+                    // harden it so a crafted item name can never carry a click/hover/insertion event
+                    // into the [item] tooltip.
+                    return ComponentSanitizer.stripInteractive(name);
                 }
             } else {
                 return LPC.getLegacySerializer().deserialize(meta.getDisplayName());

--- a/src/main/java/de/ayont/lpc/chat/PlayerMessages.java
+++ b/src/main/java/de/ayont/lpc/chat/PlayerMessages.java
@@ -54,6 +54,8 @@ public final class PlayerMessages {
         if (!allowColor) {
             return Component.text(text);
         }
-        return colorParser.deserialize(LegacyColors.toMiniMessage(text));
+        // Defence in depth: the restricted parser already rejects interactive tags, but stripInteractive
+        // guarantees no click/hover/insertion can ever survive into a player's message component.
+        return ComponentSanitizer.stripInteractive(colorParser.deserialize(LegacyColors.toMiniMessage(text)));
     }
 }

--- a/src/main/java/de/ayont/lpc/commands/LPCCommand.java
+++ b/src/main/java/de/ayont/lpc/commands/LPCCommand.java
@@ -56,8 +56,11 @@ public class LPCCommand implements CommandExecutor, TabCompleter {
 
     @SuppressWarnings("deprecation") // getDescription() is cross-platform
     private void handleVersion(CommandSender sender) {
+        String platform = plugin.isFolia() ? "Folia" : plugin.isPaper() ? "Paper" : "Spigot";
         plugin.send(sender, mini("<gradient:#B754F4:#FC00FF>LPC</gradient> <gray>v<white>"
                 + plugin.getDescription().getVersion() + "</white> <dark_gray>— <gray>MiniMessage chat formatter."));
+        plugin.send(sender, mini("<dark_gray>Platform: <white>" + platform
+                + "</white> <dark_gray>| <gray>Target: Minecraft <white>26.2</white> · Java <white>25</white> · Adventure <white>5</white>"));
     }
 
     private void handleMute(CommandSender sender, String[] args) {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,12 +1,12 @@
 name: LPC
 version: '${version}'
 main: de.ayont.lpc.LPC
-api-version: '26.1.2'
+api-version: '26.2'
 folia-supported: true
-authors: [Ayont, Varilx-Development]
+authors: [Ayont, Veylor-Development]
 depend: [LuckPerms]
 softdepend: [PlaceholderAPI]
-description: Flexible MiniMessage chat formatter for LuckPerms (Minecraft 26.1.2 / Java 25)
+description: Flexible MiniMessage chat formatter for LuckPerms (Minecraft 26.2 / Java 25 / Adventure 5)
 website: https://modrinth.com/plugin/lpc-chat
 commands:
   lpc:

--- a/src/test/java/de/ayont/lpc/chat/ComponentSanitizerTest.java
+++ b/src/test/java/de/ayont/lpc/chat/ComponentSanitizerTest.java
@@ -1,0 +1,125 @@
+package de.ayont.lpc.chat;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ComponentSanitizerTest {
+
+    private static boolean hasInteractive(Component c) {
+        if (c.style().clickEvent() != null || c.style().hoverEvent() != null || c.style().insertion() != null) {
+            return true;
+        }
+        for (Component child : c.children()) {
+            if (hasInteractive(child)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Test
+    @DisplayName("strips a click event")
+    void stripsClick() {
+        Component in = MiniMessage.miniMessage().deserialize("<click:run_command:'/op @s'>x</click>");
+        Component out = ComponentSanitizer.stripInteractive(in);
+        assertFalse(hasInteractive(out), "click must be removed");
+    }
+
+    @Test
+    @DisplayName("strips a hover event")
+    void stripsHover() {
+        Component in = MiniMessage.miniMessage().deserialize("<hover:show_text:'pwned'>x</hover>");
+        Component out = ComponentSanitizer.stripInteractive(in);
+        assertFalse(hasInteractive(out), "hover must be removed");
+    }
+
+    @Test
+    @DisplayName("strips an insertion")
+    void stripsInsertion() {
+        Component in = MiniMessage.miniMessage().deserialize("<insertion:evil>x</insertion>");
+        Component out = ComponentSanitizer.stripInteractive(in);
+        assertFalse(hasInteractive(out), "insertion must be removed");
+    }
+
+    @Test
+    @DisplayName("recurses into nested children")
+    void stripsNested() {
+        Component in = MiniMessage.miniMessage().deserialize("<red>outer <click:run_command:'/say hi'>inner</click> tail</red>");
+        Component out = ComponentSanitizer.stripInteractive(in);
+        assertFalse(hasInteractive(out), "nested interactive events must be removed");
+    }
+
+    @Test
+    @DisplayName("keeps cosmetic styling (colour, decoration)")
+    void keepsCosmetic() {
+        Component in = MiniMessage.miniMessage().deserialize("<red><bold>hi</bold></red>");
+        Component out = ComponentSanitizer.stripInteractive(in);
+        // colour + decoration must survive — only interactive events are stripped
+        boolean hasRedOrBold = hasColor(out, NamedTextColor.RED) || hasDecoration(out);
+        assertTrue(hasRedOrBold, "cosmetic styling must be preserved");
+        assertFalse(hasInteractive(out));
+    }
+
+    @Test
+    @DisplayName("null input returns an empty component")
+    void nullSafe() {
+        Component out = ComponentSanitizer.stripInteractive(null);
+        assertNotNull(out);
+        assertEquals(Component.empty(), out);
+    }
+
+    @Test
+    @DisplayName("plain text passes through unchanged in content")
+    void plainTextUnchanged() {
+        Component in = Component.text("just text");
+        Component out = ComponentSanitizer.stripInteractive(in);
+        assertEquals("just text", plain(out));
+    }
+
+    private static boolean hasColor(Component c, NamedTextColor color) {
+        if (color.equals(c.color())) {
+            return true;
+        }
+        for (Component child : c.children()) {
+            if (hasColor(child, color)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean hasDecoration(Component c) {
+        if (c.style().decorations().values().stream().anyMatch(Boolean.TRUE::equals)) {
+            return true;
+        }
+        for (Component child : c.children()) {
+            if (hasDecoration(child)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String plain(Component c) {
+        StringBuilder sb = new StringBuilder();
+        appendPlain(c, sb);
+        return sb.toString();
+    }
+
+    private static void appendPlain(Component c, StringBuilder sb) {
+        if (c instanceof net.kyori.adventure.text.TextComponent tc) {
+            sb.append(tc.content());
+        }
+        for (Component child : c.children()) {
+            appendPlain(child, sb);
+        }
+    }
+}

--- a/src/test/java/de/ayont/lpc/chat/PlayerMessagesTest.java
+++ b/src/test/java/de/ayont/lpc/chat/PlayerMessagesTest.java
@@ -18,7 +18,9 @@ class PlayerMessagesTest {
     private final MiniMessage parser = PlayerMessages.colorParser(true);
 
     private static boolean hasInteractiveEvent(Component component) {
-        if (component.style().clickEvent() != null || component.style().hoverEvent() != null) {
+        if (component.style().clickEvent() != null
+                || component.style().hoverEvent() != null
+                || component.style().insertion() != null) {
             return true;
         }
         for (Component child : component.children()) {
@@ -58,6 +60,13 @@ class PlayerMessagesTest {
     void render_hoverInjection_blocked() {
         Component result = PlayerMessages.render(parser, "<hover:show_text:'pwned'>x</hover>", true);
         assertFalse(hasInteractiveEvent(result), "hover injection must be blocked");
+    }
+
+    @Test
+    @DisplayName("never produces an insertion from a player message")
+    void render_insertionInjection_blocked() {
+        Component result = PlayerMessages.render(parser, "<insertion:evil>x</insertion>", true);
+        assertFalse(hasInteractiveEvent(result), "insertion injection must be blocked");
     }
 
     @Test

--- a/src/test/java/de/ayont/lpc/chat/UrlLinkifierTest.java
+++ b/src/test/java/de/ayont/lpc/chat/UrlLinkifierTest.java
@@ -35,7 +35,9 @@ class UrlLinkifierTest {
         ClickEvent click = firstClick(out);
         assertTrue(click != null && click.action() == ClickEvent.Action.OPEN_URL,
                 "expected an OPEN_URL click event");
-        assertTrue(click.value().contains("example.com"));
+        // Adventure 5: the URL string lives on Payload.Text, not on ClickEvent directly.
+        String href = ((ClickEvent.Payload.Text) click.payload()).value();
+        assertTrue(href.contains("example.com"), "expected the openUrl target to contain example.com");
     }
 
     @Test


### PR DESCRIPTION
## Summary

The **26.2** update. Builds, tests green, jar ships as `LPC-4.2.0.jar`.

### Platform
- Target **Paper / Minecraft 26.2** (`paper-api 26.2.build.40-alpha`), `api-version: 26.2`
- Migrate to **Adventure 5.2.0** — the version Paper 26.2 bundles (verified against the paper-api POM). Paper 26.1 shipped Adventure 4.x, so this plugin now requires Paper 26.2+.
- Fixes `Unsupported class file major version 69` build failure: **Gradle 8.14 cannot run on Java 25** (its bundled Groovy/ASM rejects Java 25 class files), so Gradle now runs on **Java 21** and compiles via the **Java 25 toolchain** (auto-provisioned by the new `foojay-resolver-convention` in `settings.gradle`).

### Dependency updates (folds in/supersedes the open Renovate PRs)
- LuckPerms `5.4 → 5.5` (#13), PlaceholderAPI `2.11.6 → 2.12.2` (#24), Gson `2.13.2 → 2.14.0` (#31), JUnit `5.11.4 → 5.14.4` (#32), Adventure BOM `4.26.1 → 5.2.0` (#29), Paper `26.1.2 → 26.2` (#35 superseded), Gradle `8.14 → 8.14.5` (#12), `actions/setup-java v5` (#19), `gradle/actions v6` (#28)

### Adventure 5 migration
- Production code only used `ClickEvent.openUrl(...)` / `.clickEvent(...)` — compatible as-is.
- Test fix: `ClickEvent` is now generic; the URL lives on `Payload.Text` (`((ClickEvent.Payload.Text) click.payload()).value()`), not `click.value()`.

### CI
- New `.github/workflows/build.yml` — runs `clean build` on every push/PR (there was no CI before).
- `publish.yml`: Java 21 Gradle runtime + 25 toolchain, bumped action versions.

### Branding & UX
- Author `Varilx-Development → Veylor-Development` (the team behind Veylor.net, free plugins on Modrinth).
- `/lpc version` now reports the detected platform + target (MC 26.2 · Java 25 · Adventure 5).
- README: compatibility table + a clear "Unsupported API version" note for users on older servers (they need Paper 26.2 + Java 25), and a direct answer to "can players use MiniMessage in chat?".

### Security (already in this branch — closes #22, #26)
- Player messages are injected as a **pre-resolved component** with a random per-render tag, **after** PlaceholderAPI runs on the format — so `%player_name%` typed by a non-op is rendered literally, never expanded.
- Player input uses a **restricted** MiniMessage parser (cosmetic tags only); interactive tags (`click`/`hover`/`insertion`) are always stripped.

### Verification
`./gradlew clean build` → BUILD SUCCESSFUL, all tests pass (Gradle on JDK 21, toolchain 25).

### Not done here
- Gradle 9 (#17) is deferred — the build still uses a couple of features deprecated in Gradle 9, and Shadow needs verifying against Gradle 9. Left open.