### PR TITLE
Add MIT LICENSE file (matches Modrinth-declared license)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024-2026 Niccolo Bodenstedt
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/readme.md
+++ b/readme.md
@@ -190,3 +190,9 @@ Requires JDK 25.
   inject commands or fake tooltips.
 - **Not affiliated with LuckPerms** – please do not contact the LuckPerms author for support.
 - Legacy version available at: [GitHub Legacy LPC](https://github.com/wikmor/LPC)
+
+---
+
+## 📄 License
+
+Released under the [MIT License](LICENSE) — matching the license declared on Modrinth.


### PR DESCRIPTION
The project declares **MIT** on Modrinth, but the GitHub repository had no `LICENSE` file — leaving it formally all-rights-reserved and inconsistent with the published metadata.

This PR:
- Adds the MIT `LICENSE` file (© 2024–2026 Niccolo Bodenstedt).
- Adds a short **License** section to the readme linking to it.

Makes the repo's licensing explicit and unambiguous — required for it to count as proper open source.